### PR TITLE
Fix/getstate localization estimator

### DIFF
--- a/include/robot_localization/robot_localization_estimator.h
+++ b/include/robot_localization/robot_localization_estimator.h
@@ -90,6 +90,7 @@ enum EstimatorResult
   ExtrapolationIntoFuture = 0,
   Interpolation,
   ExtrapolationIntoPast,
+  Exact,
   EmptyBuffer,
   Failed
 };
@@ -104,7 +105,7 @@ enum FilterType
   UKF,
   NotDefined
 };
-}  // namespace EstimatorResults
+}  // namespace FilterTypes
 typedef FilterTypes::FilterType FilterType;
 
 //! @brief Robot Localization Listener class

--- a/include/robot_localization/robot_localization_estimator.h
+++ b/include/robot_localization/robot_localization_estimator.h
@@ -123,7 +123,8 @@ public:
   //!
   explicit RobotLocalizationEstimator(unsigned int buffer_capacity,
                                       FilterType filter_type,
-                                      const std::vector<double>& filter_args=std::vector<double>());
+                                      const Eigen::MatrixXd& process_noise_covariance,
+                                      const std::vector<double>& filter_args = std::vector<double>());
 
   //! @brief Destructor for the RobotLocalizationListener class
   //!

--- a/src/robot_localization_estimator.cpp
+++ b/src/robot_localization_estimator.cpp
@@ -99,11 +99,16 @@ EstimatorResult RobotLocalizationEstimator::getState(const double time,
        it != state_buffer_.rend(); ++it)
   {
     /* If the time stamp of the current state from the buffer is
-       * older than the requested time, store it as the last state
-       * before the requested time. If it is younger, save it as the
-       * next one after, and go on to find the last one before.
-       */
-    if ( it->time_stamp <= time )
+     * older than the requested time, store it as the last state
+     * before the requested time. If it is younger, save it as the
+     * next one after, and go on to find the last one before.
+     */
+    if ( it->time_stamp == time )
+    {
+      state = *it;
+      return EstimatorResults::Exact;
+    }
+    else if ( it->time_stamp <= time )
     {
       last_state_before_time = *it;
       previous_state_found = true;

--- a/src/robot_localization_estimator.cpp
+++ b/src/robot_localization_estimator.cpp
@@ -34,13 +34,18 @@
 #include "robot_localization/ekf.h"
 #include "robot_localization/ukf.h"
 
+#include <vector>
+
 namespace RobotLocalization
 {
 RobotLocalizationEstimator::RobotLocalizationEstimator(unsigned int buffer_capacity,
                                                        FilterType filter_type,
+                                                       const Eigen::MatrixXd& process_noise_covariance,
                                                        const std::vector<double>& filter_args)
 {
   state_buffer_.set_capacity(buffer_capacity);
+
+  // Set up the filter that is used for predictions
   if ( filter_type == FilterTypes::EKF )
   {
     filter_ = new Ekf;
@@ -49,6 +54,8 @@ RobotLocalizationEstimator::RobotLocalizationEstimator(unsigned int buffer_capac
   {
     filter_ = new Ukf(filter_args);
   }
+
+  filter_->setProcessNoiseCovariance(process_noise_covariance);
 }
 
 RobotLocalizationEstimator::~RobotLocalizationEstimator()

--- a/src/robot_localization_estimator.cpp
+++ b/src/robot_localization_estimator.cpp
@@ -190,7 +190,7 @@ void RobotLocalizationEstimator::extrapolate(const EstimatorState& boundary_stat
   filter_->predict(boundary_state.time_stamp, delta);
 
   state_at_req_time.time_stamp = requested_time;
-  state_at_req_time.state = filter_->getPredictedState();
+  state_at_req_time.state = filter_->getState();
   state_at_req_time.covariance = filter_->getEstimateErrorCovariance();
 
   return;

--- a/test/test_robot_localization_estimator.cpp
+++ b/test/test_robot_localization_estimator.cpp
@@ -54,7 +54,10 @@ TEST(RLETest, StateBuffer)
 
   // Instantiate a robot localization estimator with a buffer capacity of 5
   int buffer_capacity = 5;
-  RobotLocalization::RobotLocalizationEstimator estimator(buffer_capacity, RobotLocalization::FilterTypes::EKF);
+  Eigen::MatrixXd process_noise_covariance = Eigen::MatrixXd::Identity(RobotLocalization::STATE_SIZE,
+                                                                       RobotLocalization::STATE_SIZE);
+  RobotLocalization::RobotLocalizationEstimator estimator(buffer_capacity, RobotLocalization::FilterTypes::EKF,
+                                                          process_noise_covariance);
 
   RobotLocalization::EstimatorState state;
 


### PR DESCRIPTION
Fixes a bug in the robot localization listener that resulted in predicted state vectors containing only zeros.