### PR TITLE
feature(navsat_transform): Parameter to publish "utm" as parent frame

### DIFF
--- a/doc/navsat_transform_node.rst
+++ b/doc/navsat_transform_node.rst
@@ -63,4 +63,4 @@ Published Topics
 
 Published Transforms
 ====================
-* ``world_frame->utm`` (optional) - If the ``broadcast_utm_transform`` parameter is set to  *true*, ``navsat_transform_node`` calculates a transform from the  *utm* frame to the ``frame_id`` of the input odometry data. However, to avoid re-parenting the odometry frame (and avoid making assumptions about the user's setup), we instead define the inverse transform so that the *utm* frame is a child of the odometry frame.
+* ``world_frame->utm`` (optional) - If the ``broadcast_utm_transform`` parameter is set to  *true*, ``navsat_transform_node`` calculates a transform from the  *utm* frame to the ``frame_id`` of the input odometry data. By default, the *utm* frame is published as a child of the odometry frame by using the inverse transform. With use of the ``broadcast_utm_as_parent_frame`` parameter, the *utm* frame will be published as a parent of the odometry frame. This is useful if you have multiple robots within one TF tree.

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -136,6 +136,10 @@ class NavSatTransform
     //!
     bool broadcast_utm_transform_;
 
+    //! @brief Whether to broadcast the UTM transform as parent frame, default as child
+    //!
+    bool broadcast_utm_transform_as_parent_frame_;
+
     //! @brief The frame_id of the GPS message (specifies mounting location)
     //!
     std::string gps_frame_id_;
@@ -275,6 +279,7 @@ class NavSatTransform
     //! If this parameter is true, we always report 0 for the altitude of the converted GPS odometry message.
     //!
     bool zero_altitude_;
+
 };
 
 }  // namespace RobotLocalization

--- a/params/navsat_transform_template.yaml
+++ b/params/navsat_transform_template.yaml
@@ -23,6 +23,10 @@ zero_altitude: false
 # If this is true, the transform world_frame->utm transform is broadcast for use by other nodes. Defaults to false.
 broadcast_utm_transform: false
 
+# If this is true, the utm->world_frame transform will be published instead of the world_frame->utm transform. 
+# Note that broadcast_utm_transform still has to be enabled. Defaults to false.
+broadcast_utm_transform_as_parent_frame: false
+
 # If this is true, all received odometry data is converted back to a lat/lon and published as a NavSatFix message as
 # /gps/filtered. Defaults to false.
 publish_filtered_gps: false

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -50,6 +50,7 @@ namespace RobotLocalization
     yaw_offset_(0.0),
     transform_timeout_(ros::Duration(0)),
     broadcast_utm_transform_(false),
+    broadcast_utm_transform_as_parent_frame_(false),
     has_transform_odom_(false),
     has_transform_gps_(false),
     has_transform_imu_(false),
@@ -89,6 +90,7 @@ namespace RobotLocalization
     nh_priv.getParam("magnetic_declination_radians", magnetic_declination_);
     nh_priv.param("yaw_offset", yaw_offset_, 0.0);
     nh_priv.param("broadcast_utm_transform", broadcast_utm_transform_, false);
+    nh_priv.param("broadcast_utm_transform_as_parent_frame", broadcast_utm_transform_as_parent_frame_, false);
     nh_priv.param("zero_altitude", zero_altitude_, false);
     nh_priv.param("publish_filtered_gps", publish_gps_, false);
     nh_priv.param("use_odometry_yaw", use_odometry_yaw_, false);
@@ -295,9 +297,10 @@ namespace RobotLocalization
       {
         geometry_msgs::TransformStamped utm_transform_stamped;
         utm_transform_stamped.header.stamp = ros::Time::now();
-        utm_transform_stamped.header.frame_id = world_frame_id_;
-        utm_transform_stamped.child_frame_id = "utm";
-        utm_transform_stamped.transform = tf2::toMsg(utm_world_transform_);
+        utm_transform_stamped.header.frame_id = (broadcast_utm_transform_as_parent_frame_ ? "utm" : world_frame_id_);
+        utm_transform_stamped.child_frame_id = (broadcast_utm_transform_as_parent_frame_ ? world_frame_id_ : "utm");
+        utm_transform_stamped.transform = (broadcast_utm_transform_as_parent_frame_ ?
+                                             tf2::toMsg(utm_world_trans_inverse_) : tf2::toMsg(utm_world_transform_));
         utm_transform_stamped.transform.translation.z = (zero_altitude_ ? 0.0 : utm_transform_stamped.transform.translation.z);
         utm_broadcaster_.sendTransform(utm_transform_stamped);
       }


### PR DESCRIPTION
In order to create a transformation tree with multiple robots, a common
parent frame is required. So far, it was only possible to publish "utm"
as child frame of the odometry frame. Adding this feature, the user can
specify whether to publish the "utm" transform as parent or child of the
odometry frame.