### PR TITLE
Check request validity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(ukf filter_base ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(ros_filter ekf ukf ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(robot_localization_estimator filter_utilities filter_base ekf ukf ${EIGEN3_LIBRARIES})
 target_link_libraries(ros_robot_localization_listener robot_localization_estimator ros_filter_utilities
-  ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
+  ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES} yaml-cpp)
 target_link_libraries(robot_localization_listener_node ros_robot_localization_listener ${catkin_LIBRARIES})
 target_link_libraries(ekf_localization_node ros_filter ${catkin_LIBRARIES})
 target_link_libraries(ukf_localization_node ros_filter ${catkin_LIBRARIES})

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>yaml-cpp</depend>
   
   <build_depend>message_generation</build_depend>
   <build_depend>python-catkin-pkg</build_depend>

--- a/src/ros_robot_localization_listener.cpp
+++ b/src/ros_robot_localization_listener.cpp
@@ -40,6 +40,7 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <yaml-cpp/yaml.h>
 #include <eigen_conversions/eigen_msg.h>
 
 #include <XmlRpcException.h>
@@ -244,6 +245,23 @@ void RosRobotLocalizationListener::odomAndAccelCallback(const nav_msgs::Odometry
   return;
 }
 
+bool findInParentsRecursive(YAML::Node tree, std::string source_frame, std::string target_frame)
+{
+  if ( source_frame == target_frame )
+  {
+    return true;
+  }
+
+  std::string parent_frame = tree[source_frame]["parent"].Scalar();
+
+  if ( parent_frame == "" )
+  {
+    return false;
+  }
+
+  return findInParentsRecursive(tree, parent_frame, target_frame);
+}
+
 bool RosRobotLocalizationListener::getState(const double time,
                                             const std::string& frame_id,
                                             Eigen::VectorXd& state,
@@ -313,6 +331,16 @@ bool RosRobotLocalizationListener::getState(const double time,
                                                                       world_frame_id_,
                                                                       ros::Time(time),
                                                                       ros::Duration(0.1));  // TODO: magic number
+
+      std::stringstream frames_stream(tf_buffer_.allFramesAsYAML());
+      YAML::Node frames_yaml = YAML::Load(frames_stream);
+      if ( findInParentsRecursive(frames_yaml, world_frame_id, base_frame_id_) )
+      {
+        ROS_ERROR_STREAM("You are trying to get the state with respect to world frame " << world_frame_id <<
+                         ", but this frame is a child of robot base frame " << base_frame_id_ <<
+                         ", so this doesn't make sense.");
+        return false;
+      }
     }
     catch ( tf2::LookupException e )
     {
@@ -336,6 +364,17 @@ bool RosRobotLocalizationListener::getState(const double time,
                                                           frame_id,
                                                           ros::Time(time),
                                                           ros::Duration(0.1));  // TODO: magic number
+
+    // Check that frame_id is a child of the base frame. If it is not, it does not make sense to request its state.
+    // Do this after tf lookup, so we know that there is a connection.
+    std::stringstream frames_stream(tf_buffer_.allFramesAsYAML());
+    YAML::Node frames_yaml = YAML::Load(frames_stream);
+    if ( !findInParentsRecursive(frames_yaml, frame_id, base_frame_id_) )
+    {
+      ROS_ERROR_STREAM("You are trying to get the state of " << frame_id << ", but this frame is not a child of the "
+                                                                            "base frame: " << base_frame_id_ << ".");
+      return false;
+    }
   }
   catch ( tf2::LookupException e )
   {

--- a/src/ros_robot_localization_listener.cpp
+++ b/src/ros_robot_localization_listener.cpp
@@ -245,7 +245,7 @@ void RosRobotLocalizationListener::odomAndAccelCallback(const nav_msgs::Odometry
   return;
 }
 
-bool findInParentsRecursive(YAML::Node tree, std::string source_frame, std::string target_frame)
+bool findAncestorRecursiveYAML(YAML::Node& tree, const std::string& source_frame, const std::string& target_frame)
 {
   if ( source_frame == target_frame )
   {
@@ -254,12 +254,19 @@ bool findInParentsRecursive(YAML::Node tree, std::string source_frame, std::stri
 
   std::string parent_frame = tree[source_frame]["parent"].Scalar();
 
-  if ( parent_frame == "" )
+  if ( parent_frame.empty() )
   {
     return false;
   }
 
-  return findInParentsRecursive(tree, parent_frame, target_frame);
+  return findAncestorRecursiveYAML(tree, parent_frame, target_frame);
+}
+
+bool findAncestor(const tf2_ros::Buffer& buffer, const std::string& source_frame, const std::string& target_frame)
+{
+  std::stringstream frames_stream(buffer.allFramesAsYAML());
+  YAML::Node frames_yaml = YAML::Load(frames_stream);
+  return findAncestorRecursiveYAML(frames_yaml, source_frame, target_frame);
 }
 
 bool RosRobotLocalizationListener::getState(const double time,
@@ -332,9 +339,7 @@ bool RosRobotLocalizationListener::getState(const double time,
                                                                       ros::Time(time),
                                                                       ros::Duration(0.1));  // TODO: magic number
 
-      std::stringstream frames_stream(tf_buffer_.allFramesAsYAML());
-      YAML::Node frames_yaml = YAML::Load(frames_stream);
-      if ( findInParentsRecursive(frames_yaml, world_frame_id, base_frame_id_) )
+      if ( findAncestor(tf_buffer_, world_frame_id, base_frame_id_) )
       {
         ROS_ERROR_STREAM("You are trying to get the state with respect to world frame " << world_frame_id <<
                          ", but this frame is a child of robot base frame " << base_frame_id_ <<
@@ -367,9 +372,7 @@ bool RosRobotLocalizationListener::getState(const double time,
 
     // Check that frame_id is a child of the base frame. If it is not, it does not make sense to request its state.
     // Do this after tf lookup, so we know that there is a connection.
-    std::stringstream frames_stream(tf_buffer_.allFramesAsYAML());
-    YAML::Node frames_yaml = YAML::Load(frames_stream);
-    if ( !findInParentsRecursive(frames_yaml, frame_id, base_frame_id_) )
+    if ( ! findAncestor(tf_buffer_, frame_id, base_frame_id_) )
     {
       ROS_ERROR_STREAM("You are trying to get the state of " << frame_id << ", but this frame is not a child of the "
                                                                             "base frame: " << base_frame_id_ << ".");


### PR DESCRIPTION
When the state of a frame is requested, a check is performed to be sure that it is an ancestor of the base frame, as it only makes sense to request the state of a frame connected to the robot.
The optional argument world_frame should *not* be an ancestor of the base frame, so this check is performed in the same way.