### PR TITLE
fix(lookupTransform): Use transformException

### DIFF
--- a/src/ros_robot_localization_listener.cpp
+++ b/src/ros_robot_localization_listener.cpp
@@ -347,7 +347,7 @@ bool RosRobotLocalizationListener::getState(const double time,
         return false;
       }
     }
-    catch ( tf2::LookupException e )
+    catch ( tf2::TransformException e )
     {
       ROS_WARN_STREAM("Ros Robot Localization Listener: Could not look up transform: " << e.what());
       return false;
@@ -379,7 +379,7 @@ bool RosRobotLocalizationListener::getState(const double time,
       return false;
     }
   }
-  catch ( tf2::LookupException e )
+  catch ( tf2::TransformException e )
   {
     ROS_WARN_STREAM("Ros Robot Localization Listener: Could not look up transform: " << e.what());
     return false;


### PR DESCRIPTION
A lookUpException gives a runtime error if there is not connectivity
what usually happens on initialization.