### PR TITLE
feature(initialization): Initialization update for frames and parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,10 @@ if (CATKIN_ENABLE_TESTING)
                         ${catkin_LIBRARIES}
                         ${rostest_LIBRARIES})
 
+  add_executable(test_ros_robot_localization_listener_publisher test/test_ros_robot_localization_listener_publisher.cpp)
+  target_link_libraries(test_ros_robot_localization_listener_publisher
+                        ${catkin_LIBRARIES})
+
   add_rostest_gtest(test_ros_robot_localization_listener
                     test/test_ros_robot_localization_listener.test
                     test/test_ros_robot_localization_listener.cpp)

--- a/include/robot_localization/ros_robot_localization_listener.h
+++ b/include/robot_localization/ros_robot_localization_listener.h
@@ -86,7 +86,7 @@ public:
   //!
   bool getState(const double time, const std::string& frame_id,
                 Eigen::VectorXd& state, Eigen::MatrixXd& covariance,
-                std::string world_frame_id = "");
+                std::string world_frame_id = "") const;
 
   //! @brief Get a state from the localization estimator
   //!
@@ -101,7 +101,19 @@ public:
   //!
   bool getState(const ros::Time& ros_time, const std::string& frame_id,
                 Eigen::VectorXd& state, Eigen::MatrixXd& covariance,
-                const std::string& world_frame_id = "");
+                const std::string& world_frame_id = "") const;
+
+  //!
+  //! \brief getBaseFrameId Returns the base frame id of the localization listener
+  //! \return The base frame id
+  //!
+  const std::string& getBaseFrameId() const;
+
+  //!
+  //! \brief getWorldFrameId Returns the world frame id of the localization listener
+  //! \return The world frame id
+  //!
+  const std::string& getWorldFrameId() const;
 
 private:
   //! @brief Callback for odom and accel

--- a/src/ros_robot_localization_listener.cpp
+++ b/src/ros_robot_localization_listener.cpp
@@ -67,8 +67,8 @@ FilterType filterTypeFromString(const std::string& filter_type_str)
 RosRobotLocalizationListener::RosRobotLocalizationListener(const std::string& ns):
   nh_(ns),
   nh_p_("~"+ns),
-  odom_sub_(nh_, "odometry", 1),
-  accel_sub_(nh_, "accel", 1),
+  odom_sub_(nh_, "odometry/filtered", 1),
+  accel_sub_(nh_, "accel/filtered", 1),
   sync_(odom_sub_, accel_sub_, 10),
   tf_listener_(tf_buffer_),
   base_frame_id_(""),
@@ -97,20 +97,16 @@ RosRobotLocalizationListener::RosRobotLocalizationListener(const std::string& ns
   process_noise_covariance.setZero();
   XmlRpc::XmlRpcValue process_noise_covar_config;
 
-  // Get the process noise from the parameter in the namespace of the filter node we're listening to.
-  std::string process_noise_param_namespace = odom_sub_.getTopic().substr(0, odom_sub_.getTopic().find_last_of('/'));
-  std::string process_noise_param = process_noise_param_namespace + "/process_noise_covariance";
-
-  if (!nh_param.hasParam(process_noise_param))
+  if (!nh_param.hasParam("process_noise_covariance"))
   {
-    ROS_ERROR_STREAM("Process noise covariance not found in the robot localization listener config (namespace " <<
-                     process_noise_param_namespace << ")!");
+    ROS_FATAL_STREAM("Process noise covariance not found in the robot localization listener config (namespace " <<
+                     nh_param.getNamespace() << ")! Use the ~parameter_namespace to specify the parameter namespace.");
   }
   else
   {
     try
     {
-      nh_param.getParam(process_noise_param, process_noise_covar_config);
+      nh_param.getParam("process_noise_covariance", process_noise_covar_config);
 
       ROS_ASSERT(process_noise_covar_config.getType() == XmlRpc::XmlRpcValue::TypeArray);
 

--- a/test/test_ros_robot_localization_listener.cpp
+++ b/test/test_ros_robot_localization_listener.cpp
@@ -41,85 +41,17 @@
 #include <gtest/gtest.h>
 
 RobotLocalization::RosRobotLocalizationListener* g_listener;
-ros::Publisher odom_pub;
-ros::Publisher accel_pub;
-
-TEST(LocalizationListenerTest, testGetStateBeforeReceivingMessages)
-{
-  Eigen::VectorXd state(RobotLocalization::STATE_SIZE);
-  Eigen::MatrixXd covariance(RobotLocalization::STATE_SIZE, RobotLocalization::STATE_SIZE);
-
-  ros::Time time(0);
-  std::string base_frame("base_link");
-
-  EXPECT_FALSE(g_listener->getState(time, base_frame, state, covariance));
-}
 
 TEST(LocalizationListenerTest, testGetStateOfBaseLink)
 {
+  ros::spinOnce();
+
+  ros::Time time2(1001);
+
   Eigen::VectorXd state(RobotLocalization::STATE_SIZE);
   Eigen::MatrixXd covariance(RobotLocalization::STATE_SIZE, RobotLocalization::STATE_SIZE);
 
-  double x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az;
-  x = y = z = roll = pitch = yaw = vy = vz = vroll = vpitch = vyaw = ax = ay = az = 0.0;
-  vx = 1.0;
-  vroll = M_PI/4.0;
-
-  tf2::Quaternion q;
-  q.setRPY(0, 0, 0);
-
-  ros::Time time1(1000);
-  ros::Time time2(1001);
-
-  nav_msgs::Odometry odom_msg;
-  odom_msg.header.stamp = time1;
-  odom_msg.header.frame_id = "map";
-  odom_msg.child_frame_id = "base_link";
-  odom_msg.pose.pose.position.x = x;
-  odom_msg.pose.pose.position.y = y;
-  odom_msg.pose.pose.position.y = z;
-  odom_msg.pose.pose.orientation.x = q.x();
-  odom_msg.pose.pose.orientation.y = q.y();
-  odom_msg.pose.pose.orientation.z = q.z();
-  odom_msg.pose.pose.orientation.w = q.w();
-
-  odom_msg.twist.twist.linear.x = vx;
-  odom_msg.twist.twist.linear.y = vy;
-  odom_msg.twist.twist.linear.z = vz;
-  odom_msg.twist.twist.angular.x = vroll;
-  odom_msg.twist.twist.angular.y = vpitch;
-  odom_msg.twist.twist.angular.z = vyaw;
-
-  geometry_msgs::AccelWithCovarianceStamped accel_msg;
-  accel_msg.header.stamp = time1;
-  accel_msg.header.frame_id = "base_link";
-  accel_msg.accel.accel.linear.x = ax;
-  accel_msg.accel.accel.linear.y = ay;
-  accel_msg.accel.accel.linear.z = az;
-  accel_msg.accel.accel.angular.x = 0;
-  accel_msg.accel.accel.angular.y = 0;
-  accel_msg.accel.accel.angular.z = 0;
-
-  EXPECT_EQ("/test/odometry", odom_pub.getTopic());
-  EXPECT_EQ("/test/accel", accel_pub.getTopic());
-
-  EXPECT_EQ(1, odom_pub.getNumSubscribers());
-  EXPECT_EQ(1, accel_pub.getNumSubscribers());
-
-  odom_pub.publish(odom_msg);
-  accel_pub.publish(accel_msg);
-
-  ros::Duration(0.1).sleep();
-
-  ros::spinOnce();
-
   std::string base_frame("base_link");
-
-  EXPECT_TRUE(g_listener->getState(time1, base_frame, state, covariance));
-
-  state.setZero();
-  covariance.setZero();
-
   g_listener->getState(time2, base_frame, state, covariance);
 
   EXPECT_DOUBLE_EQ(1.0, state(RobotLocalization::StateMemberX));
@@ -137,32 +69,10 @@ TEST(LocalizationListenerTest, testGetStateOfBaseLink)
 
 TEST(LocalizationListenerTest, GetStateOfRelatedFrame)
 {
+  ros::spinOnce();
+
   Eigen::VectorXd state(RobotLocalization::STATE_SIZE);
   Eigen::MatrixXd covariance(RobotLocalization::STATE_SIZE, RobotLocalization::STATE_SIZE);
-
-  tf2_ros::StaticTransformBroadcaster transform_broadcaster;
-
-  geometry_msgs::TransformStamped transformStamped;
-
-  transformStamped.header.stamp = ros::Time::now();
-  transformStamped.header.frame_id = "base_link";
-  transformStamped.child_frame_id = "sensor";
-  transformStamped.transform.translation.x = 0.0;
-  transformStamped.transform.translation.y = 1.0;
-  transformStamped.transform.translation.z = 0.0;
-  tf2::Quaternion q;
-  q.setRPY(0, 0, M_PI/2);
-  transformStamped.transform.rotation.x = q.x();
-  transformStamped.transform.rotation.y = q.y();
-  transformStamped.transform.rotation.z = q.z();
-  transformStamped.transform.rotation.w = q.w();
-
-  transform_broadcaster.sendTransform(transformStamped);
-
-  ros::Duration(0.1).sleep();
-
-  state.setZero();
-  covariance.setZero();
 
   ros::Time time1(1000);
   ros::Time time2(1001);
@@ -210,11 +120,7 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "test_robot_localization_estimator");
 
-  g_listener = new RobotLocalization::RosRobotLocalizationListener("test");
-
-  ros::NodeHandle nh;
-  odom_pub = nh.advertise<nav_msgs::Odometry>("/test/odometry", 1);
-  accel_pub = nh.advertise<geometry_msgs::AccelWithCovarianceStamped>("/test/accel", 1);
+  g_listener = new RobotLocalization::RosRobotLocalizationListener();
 
   testing::InitGoogleTest(&argc, argv);
 

--- a/test/test_ros_robot_localization_listener.test
+++ b/test/test_ros_robot_localization_listener.test
@@ -2,6 +2,67 @@
 
 <launch>
 
-    <test test-name="test_ros_robot_localization_listener" pkg="robot_localization" type="test_ros_robot_localization_listener" clear_params="true" time-limit="100.0" />
+    <node name="test_estimator" pkg="robot_localization" type="test_ros_robot_localization_listener_publisher" clear_params="true">
+      <param name="frequency" value="30"/>  
+
+      <param name="sensor_timeout" value="0.1"/>  
+
+      <param name="odom0" value="/odom_input0"/>
+      <param name="odom1" value="/odom_input1"/>
+      <param name="odom2" value="/odom_input2"/>
+
+      <param name="pose0" value="/pose_input0"/>
+      <param name="pose1" value="/pose_input1"/>
+
+      <param name="twist0" value="/twist_input0"/>
+
+      <param name="imu0" value="/imu_input0"/>
+      <param name="imu1" value="/imu_input1"/>
+      <param name="imu2" value="/imu_input2"/>
+      <param name="imu3" value="/imu_input3"/>
+
+      <rosparam param="odom0_config">[true, false, true, false, false, false, false, false, false, false, false, false, false, false, false]</rosparam>
+      <rosparam param="odom1_config">[true, true, true, true, true, true, false, false, false, false, false, false, false, false, false]</rosparam>
+      <rosparam param="odom2_config">[false, false, false, false, false, false, true, true, true, true, true, true, false, false, false]</rosparam>
+
+      <rosparam param="pose0_config">[true, false, true, false, false, false, false, false, false, false, false, false, false, false, false]</rosparam>
+      <rosparam param="pose1_config">[true, true, true, true, true, true, false, false, false, false, false, false, false, false, false]</rosparam>
+
+      <rosparam param="twist0_config">[false, false, false, false, false, false, true, true, true, true, true, true, false, false, false]</rosparam>
+
+      <rosparam param="imu0_config">[false, false, false, true, true, true, false, false, false, false, false, false, false, false, false]</rosparam>
+      <rosparam param="imu1_config">[false, false, false, false, false, false, false, false, false, true, true, true, false, false, false]</rosparam>
+      <rosparam param="imu2_config">[false, false, false, false, false, false, false, false, false, false, false, false, true, true, true]</rosparam>
+      <rosparam param="imu3_config">[false, false, false, true, true, true, false, false, false, false, false, false, false, false, false]</rosparam>
+
+      <param name="odom1_differential" value="true"/>
+      <param name="pose1_differential" value="true"/>
+      <param name="imu3_differential" value="true"/>
+
+      <param name="print_diagnostics" value="false"/>
+
+      <param name="odom_frame" value="odom"/>
+      <param name="base_link_frame" value="base_link"/>
+
+      <rosparam param="process_noise_covariance">[0.03, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.03, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.4, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.03, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.03, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.025, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.025, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.002, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.002, 0.0, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004, 0.0, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0,
+                                                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01]</rosparam>
+    </node>
+
+    <test test-name="test_ros_robot_localization_listener" pkg="robot_localization" type="test_ros_robot_localization_listener" clear_params="true" time-limit="100.0">
+      <param name="parameter_namespace" value="test_estimator" />
+    </test>
 
 </launch>

--- a/test/test_ros_robot_localization_listener_publisher.cpp
+++ b/test/test_ros_robot_localization_listener_publisher.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016, TNO IVS, Helmond
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <geometry_msgs/AccelWithCovarianceStamped.h>
+#include <nav_msgs/Odometry.h>
+#include <string>
+
+#include <ros/ros.h>
+#include <tf2/utils.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "test_robot_localization_listener_publisher");
+
+  ros::NodeHandle nh;
+  ros::Publisher odom_pub = nh.advertise<nav_msgs::Odometry>("odometry/filtered", 1);
+  ros::Publisher accel_pub = nh.advertise<geometry_msgs::AccelWithCovarianceStamped>("accel/filtered", 1);
+  tf2_ros::StaticTransformBroadcaster transform_broadcaster;
+
+  ros::Time end_time = ros::Time::now() + ros::Duration(10);
+  while (ros::ok() && ros::Time::now() < end_time)
+  {
+    ros::Time time1(1000);
+    double x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az;
+    x = y = z = roll = pitch = yaw = vy = vz = vroll = vpitch = vyaw = ax = ay = az = 0.0;
+    vx = 1.0;
+    vroll = M_PI/4.0;
+
+    tf2::Quaternion q;
+    q.setRPY(0, 0, 0);
+
+    nav_msgs::Odometry odom_msg;
+    odom_msg.header.stamp = time1;
+    odom_msg.header.frame_id = "map";
+    odom_msg.child_frame_id = "base_link";
+    odom_msg.pose.pose.position.x = x;
+    odom_msg.pose.pose.position.y = y;
+    odom_msg.pose.pose.position.y = z;
+    odom_msg.pose.pose.orientation.x = q.x();
+    odom_msg.pose.pose.orientation.y = q.y();
+    odom_msg.pose.pose.orientation.z = q.z();
+    odom_msg.pose.pose.orientation.w = q.w();
+
+    odom_msg.twist.twist.linear.x = vx;
+    odom_msg.twist.twist.linear.y = vy;
+    odom_msg.twist.twist.linear.z = vz;
+    odom_msg.twist.twist.angular.x = vroll;
+    odom_msg.twist.twist.angular.y = vpitch;
+    odom_msg.twist.twist.angular.z = vyaw;
+
+    geometry_msgs::AccelWithCovarianceStamped accel_msg;
+    accel_msg.header.stamp = time1;
+    accel_msg.header.frame_id = "base_link";
+    accel_msg.accel.accel.linear.x = ax;
+    accel_msg.accel.accel.linear.y = ay;
+    accel_msg.accel.accel.linear.z = az;
+    accel_msg.accel.accel.angular.x = 0;
+    accel_msg.accel.accel.angular.y = 0;
+    accel_msg.accel.accel.angular.z = 0;
+
+    odom_pub.publish(odom_msg);
+    accel_pub.publish(accel_msg);
+
+    geometry_msgs::TransformStamped transformStamped;
+
+    transformStamped.header.stamp = ros::Time::now();
+    transformStamped.header.frame_id = "base_link";
+    transformStamped.child_frame_id = "sensor";
+    transformStamped.transform.translation.x = 0.0;
+    transformStamped.transform.translation.y = 1.0;
+    transformStamped.transform.translation.z = 0.0;
+    {
+      tf2::Quaternion q;
+      q.setRPY(0, 0, M_PI/2);
+      transformStamped.transform.rotation.x = q.x();
+      transformStamped.transform.rotation.y = q.y();
+      transformStamped.transform.rotation.z = q.z();
+      transformStamped.transform.rotation.w = q.w();
+
+      transform_broadcaster.sendTransform(transformStamped);
+    }
+
+    ros::Duration(0.1).sleep();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
In the constructor, the robot localization listener waits for incoming
message to initialize properly. This enables the exposition of the
getFrame id methods. Also added an additional parameter_namespace
parameter to refer to the robot localization instance so that the same
filter parameters can be used, this value defaults to ~ which implies
that we search in the local namespace.