### PR TITLE
refactor(robot_localization_listener): Remap arg to robot_localization instance

### DIFF
--- a/include/robot_localization/ros_robot_localization_listener.h
+++ b/include/robot_localization/ros_robot_localization_listener.h
@@ -63,9 +63,7 @@ public:
   //! The RosRobotLocalizationListener constructor initializes nodehandles, subscribers, a filter for synchronized
   //! listening to the topics it subscribes to, and an instance of the RobotLocalizationEstimator.
   //!
-  //! @param[in] ns - namespace to place the subscribers and parameters in.
-  //!
-  explicit RosRobotLocalizationListener(const std::string& ns = "");
+  explicit RosRobotLocalizationListener();
 
   //! @brief Destructor
   //!

--- a/test/test_ros_robot_localization_listener.test
+++ b/test/test_ros_robot_localization_listener.test
@@ -62,7 +62,7 @@
     </node>
 
     <test test-name="test_ros_robot_localization_listener" pkg="robot_localization" type="test_ros_robot_localization_listener" clear_params="true" time-limit="100.0">
-      <param name="parameter_namespace" value="test_estimator" />
+      <remap from="robot_localization" to="test_estimator" />
     </test>
 
 </launch>


### PR DESCRIPTION
The parameter namespace of the listener is now by default 'robot_localization',
this parameter can be remapped to the running robot localization listener to
obtain the same parameters as the running robot localization instance.